### PR TITLE
Add support for Demagnetize mod and conveyors

### DIFF
--- a/src/main/java/com/blakebr0/pickletweaks/feature/item/ItemMagnet.java
+++ b/src/main/java/com/blakebr0/pickletweaks/feature/item/ItemMagnet.java
@@ -112,6 +112,9 @@ public class ItemMagnet extends ItemBase implements IEnableable {
 						double range = getRange();
 						List<EntityItem> items = world.getEntitiesWithinAABB(EntityItem.class, player.getEntityBoundingBox().grow(range, range, range));
 						for (EntityItem item : items) {
+							if (item.getEntityData().getBoolean("PreventRemoteMovement")) {
+								continue;
+							}
 							item.setPickupDelay(0);
 							item.setPosition(player.posX, player.posY, player.posZ);
 						}


### PR DESCRIPTION
Immersive Engineering's conveyors (and [my Demagnetize mod](https://minecraft.curseforge.com/projects/demagnetize)) add the PreventRemoteMovement boolean NBT tag to the item. This prevents them from being picked up by magnets.