### PR TITLE
Don't drop items before giving other mods an opportunity to change drops

### DIFF
--- a/src/main/java/com/blakebr0/pickletweaks/feature/FeatureRightClickHarvest.java
+++ b/src/main/java/com/blakebr0/pickletweaks/feature/FeatureRightClickHarvest.java
@@ -73,13 +73,14 @@ public class FeatureRightClickHarvest {
 				event.getEntityPlayer().swingArm(EnumHand.MAIN_HAND);
 				
 				if (!event.getWorld().isRemote) {
+					ForgeEventFactory.fireBlockHarvesting(drops, event.getWorld(), event.getPos(), state, fortune, 1.0F, false, event.getEntityPlayer());
+
 					for (ItemStack drop : drops) {
 						if (!drop.isEmpty()) {
 							crop.spawnAsEntity(event.getWorld(), event.getPos(), drop);
 						}
 					}
-				
-					ForgeEventFactory.fireBlockHarvesting(drops, event.getWorld(), event.getPos(), state, fortune, 1.0F, false, event.getEntityPlayer());
+
 					event.getWorld().setBlockState(event.getPos(), crop.withAge(0));
 				}
 			}


### PR DESCRIPTION
Creating item entities does before firing HarvestDropEvent does not allow other mods the opportunity to respond to the proposed drop array, resulting in bugs such as #33.

This adjusts the sequence so that event is fired before drops are spawned, meaning mods are free to change which drops will be spawned.