### PR TITLE
Added option for tool repairing to strip enchantments (fixes #59)

### DIFF
--- a/src/main/java/com/blakebr0/pickletweaks/config/ModConfigs.java
+++ b/src/main/java/com/blakebr0/pickletweaks/config/ModConfigs.java
@@ -52,6 +52,7 @@ public final class ModConfigs {
 
     public static final ForgeConfigSpec.BooleanValue GRID_REPAIR_ENABLED;
     public static final ForgeConfigSpec.IntValue GRID_REPAIR_COST;
+    public static final ForgeConfigSpec.BooleanValue GRID_REPAIR_STRIP_ENCHANTMENTS;
     public static final ForgeConfigSpec.BooleanValue GRID_REPAIR_DISABLE_DEFAULTS;
     public static final ForgeConfigSpec.BooleanValue GRID_REPAIR_OVERRIDE_MODE;
     public static final ForgeConfigSpec.BooleanValue GRID_REPAIR_CHEAP_SHOVEL;
@@ -137,6 +138,10 @@ public final class ModConfigs {
                 .comment("How much material should be required to fully repair a tool.")
                 .translation("configGui.pickletweaks.grid_repair_cost")
                 .defineInRange("cost", 4, 1, 8);
+        GRID_REPAIR_STRIP_ENCHANTMENTS = common
+                .comment("Crafting grid repair removes all non-curse enchantments.")
+                .translation("configGui.pickletweaks.strip_enchantments")
+                .define("stripEnchantments", false);
         GRID_REPAIR_DISABLE_DEFAULTS = common
                 .comment("Should default repair materials be disabled? Doing this makes it so ONLY the custom materials work.")
                 .translation("configGui.pickletweaks.grid_repair_disable_defaults")

--- a/src/main/java/com/blakebr0/pickletweaks/feature/crafting/GridRepairRecipe.java
+++ b/src/main/java/com/blakebr0/pickletweaks/feature/crafting/GridRepairRecipe.java
@@ -3,7 +3,10 @@ package com.blakebr0.pickletweaks.feature.crafting;
 import com.blakebr0.cucumber.helper.StackHelper;
 import com.blakebr0.pickletweaks.config.ModConfigs;
 import com.blakebr0.pickletweaks.init.ModRecipeSerializers;
+import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShovelItem;
@@ -12,8 +15,12 @@ import net.minecraft.item.crafting.ShapelessRecipe;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraftforge.registries.ForgeRegistryEntry;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class GridRepairRecipe extends ShapelessRecipe {
 	public GridRepairRecipe(ResourceLocation id) {
@@ -93,6 +100,13 @@ public class GridRepairRecipe extends ShapelessRecipe {
 		}
 
 		tool.setDamage(tool.getDamage() - (int) (damage * matCount));
+
+		/** Strip enchantments. Vanilla implementation here: {@link net.minecraft.item.crafting.RepairItemRecipe#getCraftingResult(CraftingInventory inv)}. */
+		if(ModConfigs.GRID_REPAIR_STRIP_ENCHANTMENTS.get()) {
+			Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(tool);
+			enchantments = enchantments.entrySet().stream().filter(x -> x.getKey().isCurse()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+			EnchantmentHelper.setEnchantments(enchantments, tool);
+		}
 
 		return tool;
 	}


### PR DESCRIPTION
Hello,
as you seemed to like the addition of a config option to nerf the crafting grid tool repairing (#59 ), I decided to implement it.

Happy #Hacktoberfest!