### PR TITLE
1.16 1

### DIFF
--- a/src/main/resources/data/forge/tags/items/axe/emerald.json
+++ b/src/main/resources/data/forge/tags/items/axe/emerald.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pickletweaks:emerald_axe"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/pickaxe/emerald.json
+++ b/src/main/resources/data/forge/tags/items/pickaxe/emerald.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pickletweaks:emerald_pickaxe"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/shovel/emerald.json
+++ b/src/main/resources/data/forge/tags/items/shovel/emerald.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pickletweaks:emerald_shovel"
+  ]
+}

--- a/src/main/resources/data/pickletweaks/recipes/emerald_paxel.json
+++ b/src/main/resources/data/pickletweaks/recipes/emerald_paxel.json
@@ -13,13 +13,13 @@
   ],
   "key": {
     "A": {
-      "item": "pickletweaks:emerald_axe"
+      "tag": "forge:axe/emerald"
     },
     "B": {
-      "item": "pickletweaks:emerald_pickaxe"
+      "tag": "forge:pickaxe/emerald"
     },
     "C": {
-      "item": "pickletweaks:emerald_shovel"
+      "tag": "forge:shovel/emerald"
     },
     "S": {
       "tag": "forge:rods/wooden"


### PR DESCRIPTION
I made the Emerald Paxel accept all emerald tools. I was updating a modpack that has multiple mods that add emerald tools, but not a paxel, so I didn't want to just remove this completely, so I made it accept all 